### PR TITLE
removed blank spaces in drop down

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,52 +54,54 @@
   </div>  
 
 <script>
-// Function to populate the page select dropdown
-function populatePageDropdown() {
-    const pageSelect = document.getElementById("page-select");
-    fetch("pages_list.txt")
-        .then(response => response.text())
-        .then(data => {
-            const pageFiles = data.split("\n");
-            pageFiles.forEach(pageFileName => {
-                // Trim the page file name to remove leading/trailing whitespace
-                const trimmedFileName = pageFileName.trim();
-                if (trimmedFileName !== "") {
-                    const option = document.createElement("option");
-                    option.value = "pages/" + trimmedFileName;
-                    option.textContent = trimmedFileName;
-                    pageSelect.appendChild(option);
-                }
-            });
-        })
-        .catch(error => {
-            console.error("Error fetching page list:", error);
-        });
-}
 
 
-// Function to populate the theme select dropdown
-function populateThemeDropdown() {
-    const themeSelect = document.getElementById("theme-select");
-    fetch("themes_list.txt")
-        .then(response => response.text())
-        .then(data => {
-            const themeFiles = data.split("\n");
-            themeFiles.forEach(themeFileName => {
-                // Trim the theme file name to remove leading/trailing whitespace
-                const trimmedFileName = themeFileName.trim();
-                if (trimmedFileName !== "") {
-                    const option = document.createElement("option");
-                    option.value = "themes/" + trimmedFileName;
-                    option.textContent = trimmedFileName;
-                    themeSelect.appendChild(option);
-                }
+    // Function to populate the page select dropdown
+    function populatePageDropdown() {
+        const pageSelect = document.getElementById("page-select");
+        fetch("pages_list.txt")
+            .then(response => response.text())
+            .then(data => {
+                const pageFiles = data.split("\n");
+                pageFiles.forEach(pageFileName => {
+                    // Trim the page file name to remove leading/trailing whitespace
+                    const trimmedFileName = pageFileName.trim();
+                    if (trimmedFileName !== "") {
+                        const option = document.createElement("option");
+                        option.value = "pages/" + trimmedFileName;
+                        option.textContent = trimmedFileName;
+                        pageSelect.appendChild(option);
+                    }
+                });
+            })
+            .catch(error => {
+                console.error("Error fetching page list:", error);
             });
-        })
-        .catch(error => {
-            console.error("Error fetching theme list:", error);
-        });
-}
+    }
+
+
+    // Function to populate the theme select dropdown
+    function populateThemeDropdown() {
+        const themeSelect = document.getElementById("theme-select");
+        fetch("themes_list.txt")
+            .then(response => response.text())
+            .then(data => {
+                const themeFiles = data.split("\n");
+                themeFiles.forEach(themeFileName => {
+                    // Trim the theme file name to remove leading/trailing whitespace
+                    const trimmedFileName = themeFileName.trim();
+                    if (trimmedFileName !== "") {
+                        const option = document.createElement("option");
+                        option.value = "themes/" + trimmedFileName;
+                        option.textContent = trimmedFileName;
+                        themeSelect.appendChild(option);
+                    }
+                });
+            })
+            .catch(error => {
+                console.error("Error fetching theme list:", error);
+            });
+    }
 
 
     // Call the functions to populate the dropdowns

--- a/index.html
+++ b/index.html
@@ -54,43 +54,53 @@
   </div>  
 
 <script>
-    // Function to populate the page select dropdown
-    function populatePageDropdown() {
-        const pageSelect = document.getElementById("page-select");
-        fetch("pages_list.txt")
-            .then(response => response.text())
-            .then(data => {
-                const pageFiles = data.split("\n");
-                pageFiles.forEach(pageFileName => {
+// Function to populate the page select dropdown
+function populatePageDropdown() {
+    const pageSelect = document.getElementById("page-select");
+    fetch("pages_list.txt")
+        .then(response => response.text())
+        .then(data => {
+            const pageFiles = data.split("\n");
+            pageFiles.forEach(pageFileName => {
+                // Trim the page file name to remove leading/trailing whitespace
+                const trimmedFileName = pageFileName.trim();
+                if (trimmedFileName !== "") {
                     const option = document.createElement("option");
-                    option.value = "pages/" + pageFileName;
-                    option.textContent = pageFileName;
+                    option.value = "pages/" + trimmedFileName;
+                    option.textContent = trimmedFileName;
                     pageSelect.appendChild(option);
-                });
-            })
-            .catch(error => {
-                console.error("Error fetching page list:", error);
+                }
             });
-    }
+        })
+        .catch(error => {
+            console.error("Error fetching page list:", error);
+        });
+}
 
-    // Function to populate the theme select dropdown
-    function populateThemeDropdown() {
-        const themeSelect = document.getElementById("theme-select");
-        fetch("themes_list.txt")
-            .then(response => response.text())
-            .then(data => {
-                const themeFiles = data.split("\n");
-                themeFiles.forEach(themeFileName => {
+
+// Function to populate the theme select dropdown
+function populateThemeDropdown() {
+    const themeSelect = document.getElementById("theme-select");
+    fetch("themes_list.txt")
+        .then(response => response.text())
+        .then(data => {
+            const themeFiles = data.split("\n");
+            themeFiles.forEach(themeFileName => {
+                // Trim the theme file name to remove leading/trailing whitespace
+                const trimmedFileName = themeFileName.trim();
+                if (trimmedFileName !== "") {
                     const option = document.createElement("option");
-                    option.value = "themes/" + themeFileName;
-                    option.textContent = themeFileName;
+                    option.value = "themes/" + trimmedFileName;
+                    option.textContent = trimmedFileName;
                     themeSelect.appendChild(option);
-                });
-            })
-            .catch(error => {
-                console.error("Error fetching theme list:", error);
+                }
             });
-    }
+        })
+        .catch(error => {
+            console.error("Error fetching theme list:", error);
+        });
+}
+
 
     // Call the functions to populate the dropdowns
     populatePageDropdown();

--- a/pages/omicreativedev.html
+++ b/pages/omicreativedev.html
@@ -58,25 +58,29 @@
     
   <script>
 
-
     // Function to populate the theme select dropdown
     function populateThemeDropdown() {
-        const themeSelect = document.getElementById("theme-select");
-        fetch("../themes_list.txt")
-            .then(response => response.text())
-            .then(data => {
-                const themeFiles = data.split("\n");
-                themeFiles.forEach(themeFileName => {
+    const themeSelect = document.getElementById("theme-select");
+    fetch("../themes_list.txt")
+        .then(response => response.text())
+        .then(data => {
+            const themeFiles = data.split("\n");
+            themeFiles.forEach(themeFileName => {
+                // Trim the theme file name to remove leading/trailing whitespace
+                const trimmedFileName = themeFileName.trim();
+                if (trimmedFileName !== "") {
                     const option = document.createElement("option");
-                    option.value = "../themes/" + themeFileName;
-                    option.textContent = themeFileName;
+                    option.value = "../themes/" + trimmedFileName;
+                    option.textContent = trimmedFileName;
                     themeSelect.appendChild(option);
-                });
-            })
-            .catch(error => {
-                console.error("Error fetching theme list:", error);
+                }
             });
-    }
+        })
+        .catch(error => {
+            console.error("Error fetching theme list:", error);
+        });
+}
+
 
     // Call the functions to populate the dropdowns
     populateThemeDropdown();

--- a/pages/thankyou.html
+++ b/pages/thankyou.html
@@ -56,7 +56,6 @@
   <script>
 
 
-    // Function to populate the theme select dropdown
     function populateThemeDropdown() {
         const themeSelect = document.getElementById("theme-select");
         fetch("../themes_list.txt")
@@ -64,16 +63,21 @@
             .then(data => {
                 const themeFiles = data.split("\n");
                 themeFiles.forEach(themeFileName => {
-                    const option = document.createElement("option");
-                    option.value = "../themes/" + themeFileName;
-                    option.textContent = themeFileName;
-                    themeSelect.appendChild(option);
+                    // Trim the theme file name to remove leading/trailing whitespace
+                    const trimmedFileName = themeFileName.trim();
+                    if (trimmedFileName !== "") {
+                        const option = document.createElement("option");
+                        option.value = "../themes/" + trimmedFileName;
+                        option.textContent = trimmedFileName;
+                        themeSelect.appendChild(option);
+                    }
                 });
             })
             .catch(error => {
                 console.error("Error fetching theme list:", error);
             });
     }
+
 
     // Call the functions to populate the dropdowns
     populateThemeDropdown();


### PR DESCRIPTION
## Description:

#21 There is a blank box at the bottom of both the page and theme drop down. Clicking them have unintended consequences.

Clicking the blank one in the page switcher takes you to a 404 in the pages folder.
Clicking the blank one in the theme switcher takes you to no theme.

## Solution:

In response to issue #21, I have removed the blank option at the bottom of both the page and theme dropdowns to eliminate unintended consequences.

The issue was due to blank spaces that caused the error .

I have updated the code to prevent blank spaces in the dropdown options generated from the "pages_list.txt" and  "themes_list.txt" file.

